### PR TITLE
Use svg rather than the default png for math images

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -81,6 +81,7 @@ pygments_style = 'sphinx'
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
 
+imgmath_image_format = 'svg'
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/doc/source/tech_note/Soil_Snow_Temperatures/CLM50_Tech_Note_Soil_Snow_Temperatures.rst
+++ b/doc/source/tech_note/Soil_Snow_Temperatures/CLM50_Tech_Note_Soil_Snow_Temperatures.rst
@@ -71,12 +71,12 @@ and the thickness of each layer is a function of snow depth
 
 .. math:: 
 
-   \begin{array}{lr} 
-
    \left\{ \begin{array}{l}
    snl=-1 \\ 
    \Delta z_{0} = z_{sno}
    \end{array} \right\} & \qquad {\rm for\; 0.01}\le {\rm z}_{{\rm sno}} \le 0.03 \\
+
+.. math::
 
    \left\{ \begin{array}{l}
    snl=-2  \\ 
@@ -84,11 +84,16 @@ and the thickness of each layer is a function of snow depth
    \Delta z_{0} = \Delta z_{-1}
    \end{array} \right\} & \qquad {\rm for\; 0.03}\, {\rm <}\, {\rm z}_{{\rm sno}} \le 0.04 \\ 
    
+.. math::
+
    \left\{ \begin{array}{l}
    snl=-2 \\ 
    \Delta z_{-1} = 0.02 \\
    \Delta z_{0} = z_{sno} -\Delta z_{-1}
    \end{array} \right\} & \qquad {\rm for\; 0.04}\, {\rm <}\, {\rm z}_{{\rm sno}} \le 0.07 \\ 
+
+.. math::
+
    \left\{ \begin{array}{l}
    snl=-3 \\ 
    \Delta z_{-2} = 0.02 \\ 
@@ -96,12 +101,16 @@ and the thickness of each layer is a function of snow depth
    \Delta z_{0} = \Delta z_{-1}
    \end{array} \right\} & \qquad {\rm for\; 0.07}\, {\rm <}\, {\rm z}_{{\rm sno}} \le 0.12 \\ 
    
+.. math::
+
    \left\{ \begin{array}{l}
    snl=-3 \\ 
    \Delta z_{-2} = 0.02 \\ 
    \Delta z_{-1} = 0.05 \\
    \Delta z_{0} = z_{sno} -\Delta z_{-2} -\Delta z_{-1} 
    \end{array} \right\} & \qquad {\rm for\; 0.12}\, {\rm <}\, {\rm z}_{{\rm sno}} \le 0.18 \\ 
+
+.. math::
 
    \left\{ \begin{array}{l}
    snl=-4  \\ 
@@ -111,6 +120,8 @@ and the thickness of each layer is a function of snow depth
    \Delta z_{0} =\Delta z_{-1}  
    \end{array} \right\} & \qquad {\rm for\; 0.18}\, {\rm <}\, {\rm z}_{{\rm sno}} \le 0.29 \\ 
    
+.. math::
+
    \left\{ \begin{array}{l}
    snl=-4 \\ 
    \Delta z_{-3} = 0.02  \\ 
@@ -119,6 +130,8 @@ and the thickness of each layer is a function of snow depth
    \Delta z_{0} = z_{sno} -\Delta z_{-3} -\Delta z_{-2} -\Delta z_{-1}
    \end{array} \right\} & \qquad {\rm for\; 0.29}\, {\rm <}\, {\rm z}_{{\rm sno}} \le 0.41 \\ 
 
+.. math::
+
    \left\{ \begin{array}{l}
    snl=-5  \\ 
    \Delta z_{-4} = 0.02  \\ 
@@ -126,8 +139,9 @@ and the thickness of each layer is a function of snow depth
    \Delta z_{-2} = 0.11  \\ 
    \Delta z_{-1} = {\left(z_{sno} -\Delta z_{-4} -\Delta z_{-3} -\Delta z_{-2} \right)\mathord{\left/ {\vphantom {\left(z_{sno} -\Delta z_{-4} -\Delta z_{-3} -\Delta z_{-2} \right) 2}} \right. \kern-\nulldelimiterspace} 2}  \\ 
    \Delta z_{0} = \Delta z_{-1}
-
    \end{array} \right\} & \qquad {\rm for\; 0.41}\, {\rm <}\, {\rm z}_{{\rm sno}} \le 0.64 \\ 
+
+.. math::
 
    \left\{ \begin{array}{l}
    snl=-5 \\ 
@@ -137,8 +151,6 @@ and the thickness of each layer is a function of snow depth
    \Delta z_{-1} = 0.23  \\ 
    \Delta z_{0} = z_{sno} -\Delta z_{-4} -\Delta z_{-3} -\Delta z_{-2} -\Delta z_{-1}
    \end{array} \right\} & \qquad {\rm for\; 0.64}\, {\rm <}\, {\rm z}_{{\rm sno}}
-
-   \end{array}
 
 The node depths, which are located at the midpoint of the snow layers,
 and the layer interfaces are both referenced from the soil surface and

--- a/doc/source/tech_note/Transient_Landcover/CLM50_Tech_Note_Transient_Landcover.rst
+++ b/doc/source/tech_note/Transient_Landcover/CLM50_Tech_Note_Transient_Landcover.rst
@@ -55,7 +55,7 @@ the calendar year for the current timestep,
 :math:`landuse.timeseries\_ year(nyears)` are the first and last calendar years in
 the *landuse.timeseries* dataset, respectively, :math:`nyears` is the number of
 years in the *landuse.timeseries* dataset, :math:`nt_{1}`  and :math:`nt_{2}` 
-:math:`{}_{ }`\ are the two bracketing years used in the interpolation
+are the two bracketing years used in the interpolation
 algorithm, and :math:`n` is the index value for the
 :math:`landuse.timeseries\_ year` array corresponding to
 :math:`landuse.timeseries\_ year(n)=year_{cur}` :
@@ -75,7 +75,7 @@ dataset uses a simple linear algorithm, based on the conversion of the
 current time step information into a floating-point value for the number
 of calendar days since January 1 of the current model year
 (:math:`cday`). The interpolation weight for the current time step
-:math:`tw_{cday}` \ :math:`{}_{ }`\ is
+:math:`tw_{cday}` is
 
 .. math::
    :label: 26.3) 
@@ -85,9 +85,9 @@ of calendar days since January 1 of the current model year
 where the numerator is 366 instead of 365 because the time manager
 function for CLM returns a value of :math:`cday=1.0` for midnight
 Greenwich mean time on January 1. With weights :math:`w_{p} (nt_{1} )`
-and :math:`w_{p} (nt_{2} )`\ obtained from the *landuse.timeseries* dataset for fertilizer and wood harvest
+and :math:`w_{p} (nt_{2} )` obtained from the *landuse.timeseries* dataset for fertilizer and wood harvest
 *p* at the bracketing annual time slices
-:math:`nt_{1}` \ :math:`{}_{ }`\ and :math:`nt_{2}` , the interpolated
+:math:`nt_{1}` and :math:`nt_{2}` , the interpolated
 application rate for the current time step (:math:`w_{p,t}` ) is
 
 .. math::
@@ -98,7 +98,7 @@ application rate for the current time step (:math:`w_{p,t}` ) is
 The form of this equation is designed to improve roundoff accuracy
 performance, and guarantees :math:`w_{p,t}`  stays in the range [0,1].
 Note that values for :math:`w_{p} (nt_{1} )`, :math:`w_{p} (nt_{2} )`,
-and :math:`w_{p,t}` \ :math:`{}_{ }`\ are fractional weights at the
+and :math:`w_{p,t}` are fractional weights at the
 column level of the subgrid hierarchy.
 
 The change in weight for a fertilizer or wood harvest rate between the current and previous time
@@ -130,14 +130,14 @@ balance is calculated,
    W_{tot,1} =W_{a} +W_{sno} +\sum _{i=1}^{N_{levgrnd} }\left(w_{liq,i} +w_{ice,i} \right) +\sum _{j=1}^{npft}\left(W_{can,j} wt_{j,1} \right)
 
 where :math:`W_{a}`  is the aquifer water, :math:`W_{sno}`  is the snow
-water, :math:`w_{liq,i}`  and :math:`w_{ice,i}` \ are the liquid and ice
-soil water contents, :math:`W_{can,j}` \ is the canopy water content for
+water, :math:`w_{liq,i}`  and :math:`w_{ice,i}` are the liquid and ice
+soil water contents, :math:`W_{can,j}` is the canopy water content for
 PFT and CFT :math:`j`, and :math:`wt_{j,1}`  is the PFT or CFT weight for
 :math:`j`. For the situation where PFT and CFT weights are changing, any difference 
-between :math:`W_{tot,1}`  and :math:`W_{tot,2}` \ are due to
+between :math:`W_{tot,1}`  and :math:`W_{tot,2}` are due to
 differences in the total canopy water before and after the PFT and CFT weight
 change. To ensure conservation, the typically very small
-difference between :math:`W_{tot,2}` \ and :math:`W_{tot,1}`  is
+difference between :math:`W_{tot,2}` and :math:`W_{tot,1}`  is
 subtracted from the grid cell runoff
 
 .. math::

--- a/doc/source/tech_note/conf.py
+++ b/doc/source/tech_note/conf.py
@@ -81,6 +81,7 @@ pygments_style = 'sphinx'
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
 
+imgmath_image_format = 'svg'
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/doc/source/users_guide/conf.py
+++ b/doc/source/users_guide/conf.py
@@ -81,6 +81,7 @@ pygments_style = 'sphinx'
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
 
+imgmath_image_format = 'svg'
 
 # -- Options for HTML output ----------------------------------------------
 


### PR DESCRIPTION
This makes the images appear much more crisp - less blurry.

I did a quick visual inspection of the resulting html, and found a few
problems with the svg images that I needed to fix:

- CLM50_Tech_Note_Soil_Snow_Temperatures.rst

  There was a long array equation that didn't get rendered properly. I
  fixed this by breaking it into a bunch of separate
  equations. (Breaking it into two arrays worked, too, but it seemed
  cleaner just to break it into all of its pieces.)

- CLM50_Tech_Note_Transient_Landcover.rst

  There were a few buggy math equations.

  I also cleaned this up a bit by removing some unnecessary '\'
  characters.

It would be worth someone else doing a quick look through this, after rebuilding the html, to make sure it all looks good. Also, I haven't looked at the resulting pdf, because I'm not sure how to generate that.
